### PR TITLE
fix: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -1,4 +1,4 @@
-declare module "@vue/runtime-core" {
+declare module "vue" {
   export interface GlobalComponents {
     VueToPrint: typeof import("vue-to-print")["VueToPrint"];
   }


### PR DESCRIPTION
**Problem**: after https://github.com/nuxt/nuxt/pull/28446, the mixing of module augmentation causes issues for modules downstream like `vue-to-print` which cause typescript intellisense to break completely (e.g. in vscode).

**Solution**: this PR removes augmentations of `@vue/runtime-core` in favour of only augmenting `vue` (the new recommendation), which should fix issues when other packages (like `vue-to-print`) are only augmenting `vue` (see https://github.com/nuxt/nuxt/pull/28542)